### PR TITLE
CCB-496: modified image resize to use vips_reduce

### DIFF
--- a/resize.go
+++ b/resize.go
@@ -167,7 +167,7 @@ func transformImage(image *C.VipsImage, o Options, shrink int, residual float64)
 
 	debug("Transform: shrink=%v, residual=%v", shrink, residual)
 
-	// Use vips_shrink with the integral reduction down to shrink >= 2
+	// Use vips_shrink with the integral reduction down to shrink >= 4
 	if shrink >= 4 {
 		image, residual, err = shrinkImage(image, o, residual, shrink / 2)
 		if err != nil {

--- a/vips.go
+++ b/vips.go
@@ -420,6 +420,18 @@ func vipsShrink(input *C.VipsImage, shrink int) (*C.VipsImage, error) {
 	return image, nil
 }
 
+func vipsReduce(input *C.VipsImage, xshrink, yshrink float64) (*C.VipsImage, error) {
+	var image *C.VipsImage
+	defer C.g_object_unref(C.gpointer(input))
+
+	err := C.vips_reduce_bridge(input, &image, C.double(xshrink), C.double(yshrink))
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+
+	return image, nil
+}
+
 func vipsEmbed(input *C.VipsImage, left, top, width, height, extend int) (*C.VipsImage, error) {
 	var image *C.VipsImage
 	defer C.g_object_unref(C.gpointer(input))

--- a/vips.h
+++ b/vips.h
@@ -118,6 +118,11 @@ vips_shrink_bridge(VipsImage *in, VipsImage **out, double xshrink, double yshrin
 }
 
 int
+vips_reduce_bridge(VipsImage *in, VipsImage **out, double xshrink, double yshrink) {
+	return vips_reduce(in, out, xshrink, yshrink, NULL);
+}
+
+int
 vips_rotate(VipsImage *in, VipsImage **out, int angle) {
 	int rotate = VIPS_ANGLE_D0;
 


### PR DESCRIPTION
Tied to https://github.com/Hearst-Hatchery/hips/pull/117

Some background information in
https://thetower.atlassian.net/wiki/display/~oertekin/CCB-1+Investigate+Image+Resize+Algorithms

Recommendations section describes what's being done here.

Basically the previous code would "shrink" (by simple resampling) an image down to 1x+ and then use affine transformation (`vips_affine`) for the rest of the way. But most of the resolution would be lost in the resampling step.

Resampling happens in 2 places, either on load (for jpeg images) in
https://github.com/Hearst-Hatchery/bimg/pull/1/files#diff-74528e36b4b8b8eea1504e3e95b0178aR374
or after load in
https://github.com/Hearst-Hatchery/bimg/pull/1/files#diff-74528e36b4b8b8eea1504e3e95b0178aR354

I've changed it so that we "shrink" down to 2x+ (instead of 1x+) and then if the resulting image fits `vips_reduce` requirements, use `vips_reduce` (which uses Lanczos algorithm) for the rest of the resize operation, or otherwise falls back to `vips_affine`.